### PR TITLE
Fix version import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,29 @@
+import codecs
+import os.path
+
 from setuptools import setup, find_packages
 
-from medio import __version__
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 
 with open('README.md') as f:
     long_description = f.read()
 
-
 setup(name='medio',
-      version=__version__,
+      version=get_version("medio/__init__.py"),
       description='Medical images I/O python package',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -17,31 +33,31 @@ setup(name='medio',
       keywords=['medical-images', 'IO', 'itk', 'nibabel', 'pydicom', 'python'],
       packages=find_packages(exclude=['*.tests']),
       install_requires=[
-            'itk >= 5.1.2',
-            'nibabel >= 3.2.1',
-            'pydicom >= 2.1.2',
-            'dicom-numpy >= 0.5.0',
-            'numpy >= 1.18.1'
+          'itk >= 5.1.2',
+          'nibabel >= 3.2.1',
+          'pydicom >= 2.1.2',
+          'dicom-numpy >= 0.5.0',
+          'numpy >= 1.18.1',
       ],
       python_requires='>=3.6',
       classifiers=[
-            'Development Status :: 3 - Alpha',
+          'Development Status :: 3 - Alpha',
 
-            'Intended Audience :: Developers',
-            'Intended Audience :: Education',
-            'Intended Audience :: Healthcare Industry',
-            'Intended Audience :: Science/Research',
+          'Intended Audience :: Developers',
+          'Intended Audience :: Education',
+          'Intended Audience :: Healthcare Industry',
+          'Intended Audience :: Science/Research',
 
-            'Topic :: Scientific/Engineering :: Medical Science Apps.',
-            'Topic :: Software Development :: Libraries :: Python Modules',
+          'Topic :: Scientific/Engineering :: Medical Science Apps.',
+          'Topic :: Software Development :: Libraries :: Python Modules',
 
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
 
-            'Operating System :: OS Independent'
+          'Operating System :: OS Independent',
       ],
       license='Apache License 2.0',
       zip_safe=True)

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,14 @@
-import codecs
-import os.path
-
 from setuptools import setup, find_packages
 
 
-def read(rel_path):
-    here = os.path.abspath(os.path.dirname(__file__))
-    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
-        return fp.read()
-
-
 def get_version(rel_path):
-    for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
+    with open(rel_path, 'r') as fp:
+        for line in fp:
+            if line.startswith('__version__'):
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
+        else:
+            raise RuntimeError("Unable to find version string.")
 
 
 with open('README.md') as f:


### PR DESCRIPTION
Currently, building the package from source with
`pip install -e path/to/medio/`
fails as `__init__.py` imports some packages that are not yet installed.
This PR fixes this issue.