### PR TITLE
fix: hard-fail on geometrically inconsistent DICOM series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+## 0.7.0
+
+### Breaking
+
+- **DICOM series are now geometrically validated, and an inconsistent series raises instead of
+  returning a wrong image.** Reading a DICOM directory whose slices do not form a single consistent
+  3D volume now raises `medio.InconsistentSeriesError` (a `ValueError` subclass).
+
+  Grouping slices by Series Instance UID does not identify a volume: scanners emit a localizer/scout
+  slice under the *same* Series Instance UID, Series Number and Series Description as the acquisition
+  it belongs to. Including it corrupts the derived geometry, because the slice spacing is computed
+  across the whole set — one distant off-axis slice stretches every voxel along the slice axis. On a
+  real clinical CT this silently turned a 0.700 mm spacing into 0.81662 mm, a 16.7% geometric error,
+  with no error and no exception.
+
+  The underlying libraries do not catch this: ITK's `ImageSeriesReader` only emits a
+  `Non uniform sampling or missing slices detected` **warning** and proceeds.
+
+  Three invariants are enforced, each a property any single 3D volume must have:
+  1. all slices share one orientation (direction cosines),
+  2. all slices share one in-plane geometry (pixel spacing, rows, columns),
+  3. slice positions are uniformly spaced along the slice normal (this also catches missing and
+     duplicated slices, not only localizers).
+
+  Agreement between the derived spacing and the `SliceThickness` tag is deliberately **not**
+  required: gapped and overlapping reconstructions are legitimate, so `SliceThickness != spacing` is
+  not an inconsistency.
+
+  Tolerances are calibrated against 68 real CT series, in which healthy series deviate from a uniform
+  gap by at most 1e-3 relative (median 5e-14) and per-slice orientation by at most 3.4e-5 degrees,
+  while a genuinely broken stack deviated by 9.7e-1. The defaults sit about 10x above observed noise
+  and 100x below a real defect.
+
+  **To restore the previous behaviour**, pass `validate_series=False`. This returns the same
+  (incorrect) geometry as before rather than a repaired one — an explicit opt-out means exactly what
+  it says.
+
+### Added
+
+- `keep_dominant_geometry=False` on `read_img` / `read_meta` for DICOM directories: read only the
+  slices sharing the dominant geometry, discarding e.g. a localizer. It filters first and then still
+  validates what remains, so it never hides a genuine gap in the slices it keeps.
+- `medio.InconsistentSeriesError`, and the `medio.utils.dcm_series` module holding the validator.
+  Error messages name the offending files, report observed versus expected slice gaps, and state how
+  to bypass the check.
+
+### Fixed
+
+- `read_meta(backend='pdcm')` and `read_img(backend='pdcm')` no longer disagree on the same
+  directory. Previously `read_img` delegated to `dicom_numpy`, which validates, while `read_meta`
+  used an internal affine computation that did not — so one raised and the other silently returned a
+  corrupted affine. Both share the validator now.
+- `read_meta(backend='pdcm')` on a series whose localizer sorts first by `InstanceNumber` no longer
+  derives the affine origin from that slice.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,34 @@ arr, meta = medio.read_img('scan.mhd')
 medio.save_dir('dicom_out/', arr, meta)
 ```
 
+### DICOM series geometry is validated
+
+A DICOM directory is only a valid 3D volume if its slices agree geometrically. Series Instance UID
+does not guarantee that: scanners emit a localizer/scout under the **same** Series Instance UID as
+the acquisition, and reading it as part of the volume silently corrupts the derived slice spacing.
+`read_img` and `read_meta` therefore refuse an inconsistent series instead of returning a wrong
+image:
+
+```python
+medio.read_img('dicom_dir/')
+# InconsistentSeriesError: DICOM series mixes slice orientations: 1 of 325 slice(s) are not
+# parallel to the first ... typically a localizer/scout slice sharing the Series Instance UID.
+
+# read only the slices that share the dominant geometry (drops the localizer):
+arr, meta = medio.read_img('dicom_dir/', keep_dominant_geometry=True)
+
+# opt out entirely and get the previous, unchecked behaviour:
+arr, meta = medio.read_img('dicom_dir/', validate_series=False)
+```
+
+The checks are the invariants any single volume must satisfy — one orientation, one in-plane
+geometry, uniformly spaced slice positions — and they catch missing or duplicated slices as well as
+localizers. `SliceThickness` is deliberately **not** required to equal the slice spacing: gapped and
+overlapping reconstructions are legitimate.
+
+`keep_dominant_geometry` filters first and then still validates what remains, so it discards
+off-geometry slices without hiding a genuine gap in the rest.
+
 ### Spatial slicing with automatic affine update
 
 ```python
@@ -97,7 +125,12 @@ medio.read_img(input_path, desired_ornt=None, backend=None, dtype=None,
 | `channels_axis` | int \| None | `-1` | Axis for multi-channel (e.g. RGB) images |
 | `coord_sys` | `'itk'` \| `'nib'` \| None | `'itk'` | Coordinate convention for orientation and metadata |
 
-`**kwargs` are passed to the backend. ITK-specific: `pixel_type`, `fallback_only`, `series`. pydicom-specific: `globber`, `allow_default_affine`, `series`.
+`**kwargs` are passed to the backend. DICOM directories (both backends): `series`, `validate_series`, `keep_dominant_geometry`. ITK-specific: `pixel_type`, `fallback_only`. pydicom-specific: `globber`, `allow_default_affine`.
+
+| DICOM-directory parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `validate_series` | bool | `True` | Raise `InconsistentSeriesError` unless the slices form one consistent 3D volume. `False` restores the previous, unchecked behaviour |
+| `keep_dominant_geometry` | bool | `False` | Read only the slices sharing the dominant geometry, discarding e.g. a localizer that shares the Series Instance UID |
 
 ---
 

--- a/medio/__init__.py
+++ b/medio/__init__.py
@@ -7,12 +7,14 @@ from medio.medimg import MedImg
 from medio.metadata.affine import Affine
 from medio.metadata.metadata import CoordSys, MetaData
 from medio.read_save import read_img, read_meta, save_dir, save_img
+from medio.utils.dcm_series import InconsistentSeriesError
 
 __version__ = version("medio")
 
 __all__ = [
     "Affine",
     "CoordSys",
+    "InconsistentSeriesError",
     "ItkIO",
     "MedImg",
     "MetaData",

--- a/medio/backends/itk_io.py
+++ b/medio/backends/itk_io.py
@@ -12,6 +12,7 @@ from medio.metadata.affine import Affine
 from medio.metadata.dcm_uid import generate_uid
 from medio.metadata.itk_orientation import itk_orientation_code
 from medio.metadata.metadata import MetaData, check_dcm_ornt
+from medio.utils.dcm_series import resolve_series_files
 from medio.utils.files import is_dicom, make_dir, parse_series_uids
 
 if TYPE_CHECKING:
@@ -40,6 +41,8 @@ class ItkIO:
         fallback_only: bool = True,
         series: str | int | None = None,
         private_tags: bool = False,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> tuple[NDArray[np.generic], MetaData[object]]:
         """
         The main reader function, reads images and performs reorientation and unpacking
@@ -50,6 +53,10 @@ class ItkIO:
         :param pixel_type: preferred itk pixel type for the image
         :param fallback_only: if True, finds the pixel_type automatically and uses pixel_type only if failed
         :param series: str or int of the series to read (in the case of multiple series in a directory)
+        :param validate_series: for a dicom directory, verify that the slices form one consistent 3d volume and
+        raise InconsistentSeriesError otherwise. Set False to restore the previous, unchecked behaviour
+        :param keep_dominant_geometry: for a dicom directory, read only the slices sharing the dominant geometry,
+        discarding e.g. a localizer that shares the Series Instance UID
         :return: numpy image and metadata object which includes pixdim, affine, original orientation string and
         coordinates system
         """
@@ -66,7 +73,15 @@ class ItkIO:
             if imageio is not None:
                 # fallback_only=True would skip the imageio, so disable it
                 fallback_only = False
-            img = ItkIO.read_dir(str(input_path), pixel_type, fallback_only, series, imageio)
+            img = ItkIO.read_dir(
+                str(input_path),
+                pixel_type,
+                fallback_only,
+                series,
+                imageio,
+                validate_series=validate_series,
+                keep_dominant_geometry=keep_dominant_geometry,
+            )
         elif input_path.is_file():
             # If the input file is not a dicom (e.g. NIfTI), fallback to not use imageio.
             use_dicom_imageio = imageio is not None and imageio.CanReadFile(str(input_path))
@@ -109,6 +124,8 @@ class ItkIO:
         fallback_only: bool = True,
         series: str | int | None = None,
         private_tags: bool = False,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> MetaData[object]:
         """
         Read only the metadata (affine, orientation, spatial shape) without loading pixel data.
@@ -120,6 +137,8 @@ class ItkIO:
         :param fallback_only: if True, auto-detect pixel type
         :param series: series to read when a directory has multiple series
         :param private_tags: if True, also load private DICOM tags (requires header=True)
+        :param validate_series: for a dicom directory, verify that the slices form one consistent 3d volume
+        :param keep_dominant_geometry: for a dicom directory, use only the slices sharing the dominant geometry
         :return: MetaData with spatial_shape set
         """
 
@@ -130,7 +149,12 @@ class ItkIO:
         image_type = itk.Image[pixel_type, ItkIO.dimension]
 
         if input_path.is_dir():
-            filenames = ItkIO.extract_series(str(input_path), series)
+            filenames = ItkIO.extract_series(
+                str(input_path),
+                series,
+                validate_series=validate_series,
+                keep_dominant_geometry=keep_dominant_geometry,
+            )
             reader = itk.ImageSeriesReader[image_type].New()
             if isinstance(filenames, str):
                 reader.SetFileNames([filenames])
@@ -460,6 +484,8 @@ class ItkIO:
         fallback_only: bool = False,
         series: str | int | None = None,
         imageio: object | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> object:
         """
         Read a dicom directory. If there is more than one series in the directory an error is raised
@@ -467,21 +493,36 @@ class ItkIO:
         Shorter option for a single series (provided the slices order is known):
         >>> itk.imread([filename0, filename1, ...])
         """
-        filenames = ItkIO.extract_series(dirname, series)
+        filenames = ItkIO.extract_series(
+            dirname, series, validate_series=validate_series, keep_dominant_geometry=keep_dominant_geometry
+        )
         return itk.imread(filenames, pixel_type, fallback_only, imageio)
 
     @staticmethod
-    def extract_series(dirname: str, series: str | int | None = None) -> list[str] | str:
-        """Extract series filenames from the directory dirname"""
+    def extract_series(
+        dirname: str,
+        series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
+    ) -> list[str] | str:
+        """Extract series filenames from the directory dirname.
+
+        Series Instance UID alone does not identify a volume: a localizer/scout can share it with the
+        acquisition, and including it silently corrupts the derived slice spacing. So the grouped
+        filenames are geometry-checked before they are read (see medio.utils.dcm_series).
+        """
         names_generator = itk.GDCMSeriesFileNames.New()
         names_generator.SetDirectory(dirname)
 
         series_uids = names_generator.GetSeriesUIDs()
         series_uid = parse_series_uids(dirname, series_uids, series)
 
-        filenames = names_generator.GetFileNames(series_uid)
+        filenames = list(names_generator.GetFileNames(series_uid))
+        filenames = resolve_series_files(
+            filenames, validate=validate_series, keep_dominant_geometry=keep_dominant_geometry
+        )
         if len(filenames) == 1:
-            filenames = filenames[0]  # there is a single image in the series
+            return filenames[0]  # there is a single image in the series
 
         return filenames
 

--- a/medio/backends/pdcm_io.py
+++ b/medio/backends/pdcm_io.py
@@ -14,6 +14,7 @@ from medio.backends.pdcm_unpack_ds import affine_from_dataset, unpack_dataset
 from medio.metadata.convert_nib_itk import inv_axcodes
 from medio.metadata.metadata import MetaData
 from medio.metadata.pdcm_ds import MultiFrameFileDataset, convert_ds
+from medio.utils.dcm_series import resolve_series_datasets
 from medio.utils.files import parse_series_uids
 
 if TYPE_CHECKING:
@@ -38,6 +39,8 @@ class PdcmIO:
         globber: str = "*",
         allow_default_affine: bool = False,
         series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> tuple[NDArray[np.generic], MetaData[object]]:
         """
         Read a dicom file or folder (series) and return the numpy array and the corresponding metadata
@@ -50,6 +53,10 @@ class PdcmIO:
         :param globber: relevant for a directory - globber for selecting the series files (all files by default)
         :param allow_default_affine: whether to allow default affine when some tags are missing (multiframe file only)
         :param series: str or int of the series to read (in the case of multiple series in a directory)
+        :param validate_series: for a directory, verify that the slices form one consistent 3d volume and raise
+        InconsistentSeriesError otherwise. Set False to restore the previous, unchecked behaviour
+        :param keep_dominant_geometry: for a directory, read only the slices sharing the dominant geometry,
+        discarding e.g. a localizer that shares the Series Instance UID
         :return: numpy array and metadata
         """
         input_path = Path(input_path)
@@ -62,6 +69,8 @@ class PdcmIO:
                 globber,
                 channels_axis=temp_channels_axis,
                 series=series,
+                validate_series=validate_series,
+                keep_dominant_geometry=keep_dominant_geometry,
             )
         else:
             img, metadata, channeled = PdcmIO.read_dcm_file(
@@ -84,6 +93,8 @@ class PdcmIO:
         globber: str = "*",
         allow_default_affine: bool = False,
         series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> MetaData[object]:
         """
         Read only the metadata (affine, orientation, spatial shape) of a DICOM file or directory without loading pixel
@@ -100,7 +111,13 @@ class PdcmIO:
 
         input_path = Path(input_path)
         if input_path.is_dir():
-            slices = PdcmIO.extract_slices_no_pixels(input_path, globber, series)
+            slices = PdcmIO.extract_slices_no_pixels(
+                input_path,
+                globber,
+                series,
+                validate_series=validate_series,
+                keep_dominant_geometry=keep_dominant_geometry,
+            )
             affine = PdcmIO._compute_series_affine(slices)
             ds0 = slices[0]
             spatial_shape: tuple[int, ...] = (int(ds0.Columns), int(ds0.Rows), len(slices))
@@ -216,13 +233,21 @@ class PdcmIO:
         globber: str = "*",
         channels_axis: int | None = None,
         series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> tuple[NDArray[np.generic], MetaData[object], bool]:
         """
         Reads a 3D dicom image: input path can be a file or directory (DICOM series).
         Return the image array, metadata, and whether it has channels
         """
         # find all dicom files within the specified folder, read every file separately and sort them by InstanceNumber
-        slices = PdcmIO.extract_slices(input_dir, globber=globber, series=series)
+        slices = PdcmIO.extract_slices(
+            input_dir,
+            globber=globber,
+            series=series,
+            validate_series=validate_series,
+            keep_dominant_geometry=keep_dominant_geometry,
+        )
         img, affine = combine_slices(slices)
         metadata = PdcmIO.aff2meta(affine)
         if header:
@@ -244,6 +269,8 @@ class PdcmIO:
         input_dir: str | os.PathLike[str],
         globber: str = "*",
         series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> list[pydicom.Dataset]:
         """Extract slices from input_dir and return them sorted"""
         files = Path(input_dir).glob(globber)
@@ -259,13 +286,17 @@ class PdcmIO:
         slices = datasets[series_uid]
 
         slices.sort(key=lambda ds: ds.get("InstanceNumber", 0))
-        return slices
+        # Series Instance UID does not identify a volume on its own: a localizer can share it, and
+        # sorting by InstanceNumber can place it first, poisoning the origin as well as the spacing.
+        return resolve_series_datasets(slices, validate=validate_series, keep_dominant_geometry=keep_dominant_geometry)
 
     @staticmethod
     def extract_slices_no_pixels(
         input_dir: str | os.PathLike[str],
         globber: str = "*",
         series: str | int | None = None,
+        validate_series: bool = True,
+        keep_dominant_geometry: bool = False,
     ) -> list[pydicom.Dataset]:
         """Extract slices from input_dir without loading pixel data (header-only).
         Returns sorted list of pydicom Datasets read with stop_before_pixels=True."""
@@ -280,7 +311,7 @@ class PdcmIO:
         series_uid = parse_series_uids(input_dir, datasets.keys(), series, globber)
         slices = datasets[series_uid]
         slices.sort(key=lambda ds: ds.get("InstanceNumber", 0))
-        return slices
+        return resolve_series_datasets(slices, validate=validate_series, keep_dominant_geometry=keep_dominant_geometry)
 
     @staticmethod
     def aff2meta(affine: NDArray[np.floating]) -> MetaData[object]:

--- a/medio/utils/dcm_series.py
+++ b/medio/utils/dcm_series.py
@@ -1,0 +1,317 @@
+"""Geometric validation of a DICOM series: does this set of slices describe ONE 3D volume?
+
+Grouping slices by Series Instance UID is not sufficient. Scanners do emit a localizer/scout under
+the *same* Series Instance UID, Series Number and Series Description as the acquisition it belongs
+to, differing only in orientation and pixel spacing. Such a slice is not part of the volume, and
+including it corrupts the derived geometry: the slice spacing is computed across the whole set, so
+one distant off-axis slice silently stretches every voxel along the slice axis.
+
+That failure is silent by default in the underlying libraries -- ITK's ImageSeriesReader only emits
+a "Non uniform sampling or missing slices detected" *warning* and proceeds -- which makes it exactly
+the kind of defect that reaches downstream measurements unnoticed. Hence the checks here are
+hard-failing, with an explicit opt-out.
+
+Three invariants are enforced, all properties any single 3D volume must have:
+  1. every slice shares one orientation (direction cosines),
+  2. every slice shares one in-plane geometry (pixel spacing, rows, columns),
+  3. slice positions along the slice normal are uniformly spaced.
+
+Deliberately NOT enforced: agreement between the derived spacing and the SliceThickness tag. Gapped
+and overlapping reconstructions are legitimate and common, so `SliceThickness != spacing` is not an
+inconsistency -- treating it as one would reject valid data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pydicom
+
+if TYPE_CHECKING:
+    import os
+    from collections.abc import Iterable, Sequence
+
+    from numpy.typing import NDArray
+
+
+# Tolerances calibrated against 68 real CT series: healthy series deviate from a uniform gap by
+# <= 1e-3 relative (median 5e-14), and their per-slice orientation varies by <= 3.4e-5 degrees. A
+# genuinely broken stack in the same sample deviated by 9.7e-1. These defaults therefore sit ~10x
+# above observed noise and ~100x below a real defect.
+DEFAULT_SPACING_RTOL = 1e-2
+DEFAULT_SPACING_ATOL = 1e-4  # mm; keeps sub-micron noise on very thin slices from tripping the check
+DEFAULT_ANGLE_TOL_DEG = 1e-3
+
+_GEOMETRY_TAGS = [
+    "ImageOrientationPatient",
+    "ImagePositionPatient",
+    "PixelSpacing",
+    "Rows",
+    "Columns",
+]
+
+_BYPASS_HINT = (
+    "Pass validate_series=False to read it anyway (the geometry will be wrong), or "
+    "keep_dominant_geometry=True to read only the slices that share the dominant geometry."
+)
+
+
+class InconsistentSeriesError(ValueError):
+    """A DICOM series does not describe a single consistent 3D volume.
+
+    Subclasses ValueError so that callers already handling malformed input keep working.
+    """
+
+
+@dataclass(frozen=True)
+class SliceGeometry:
+    """The geometry of one slice, plus a human-readable key for error messages."""
+
+    key: str
+    orientation: tuple[float, ...]
+    position: tuple[float, ...]
+    pixel_spacing: tuple[float, float]
+    shape: tuple[int, int]
+
+    @property
+    def normal(self) -> NDArray[np.float64]:
+        row, col = np.asarray(self.orientation[:3], float), np.asarray(self.orientation[3:], float)
+        n = np.cross(row, col)
+        norm = float(np.linalg.norm(n))
+        if norm == 0:
+            raise InconsistentSeriesError(f"Degenerate ImageOrientationPatient in {self.key}: {self.orientation}")
+        return n / norm
+
+    @property
+    def in_plane(self) -> tuple[float, float, int, int]:
+        """The properties that must match for slices to stack into one array."""
+        return (*self.pixel_spacing, *self.shape)
+
+
+def geometry_from_dataset(ds: pydicom.Dataset, key: str) -> SliceGeometry | None:
+    """None when the dataset carries no slice geometry (e.g. a non-image DICOM object)."""
+    if not hasattr(ds, "ImageOrientationPatient") or not hasattr(ds, "ImagePositionPatient"):
+        return None
+    ornt = tuple(float(x) for x in ds.ImageOrientationPatient)
+    pos = tuple(float(x) for x in ds.ImagePositionPatient)
+    spacing = getattr(ds, "PixelSpacing", None)
+    pixel_spacing = (float(spacing[0]), float(spacing[1])) if spacing is not None else (1.0, 1.0)
+    shape = (int(getattr(ds, "Rows", 0)), int(getattr(ds, "Columns", 0)))
+    if len(ornt) != 6 or len(pos) != 3:
+        return None
+    return SliceGeometry(key=key, orientation=ornt, position=pos, pixel_spacing=pixel_spacing, shape=shape)
+
+
+def geometry_from_file(path: str | os.PathLike[str]) -> SliceGeometry | None:
+    """Read only the geometry tags, so validating a series stays cheap next to reading pixels."""
+    try:
+        ds = pydicom.dcmread(str(path), stop_before_pixels=True, specific_tags=_GEOMETRY_TAGS)
+    except Exception:
+        return None
+    return geometry_from_dataset(ds, key=str(path))
+
+
+def geometries_from_files(paths: Iterable[str | os.PathLike[str]]) -> list[SliceGeometry]:
+    return [g for g in (geometry_from_file(p) for p in paths) if g is not None]
+
+
+def select_dominant(geometries: Sequence[SliceGeometry]) -> tuple[list[SliceGeometry], list[SliceGeometry]]:
+    """Split into the slices sharing the most common (orientation, in-plane geometry) and the rest.
+
+    Ties are broken deterministically by the first-seen group, so repeated reads of one directory
+    always yield the same volume.
+    """
+    if not geometries:
+        return [], []
+    order: list[tuple[tuple[float, ...], tuple[float, float, int, int]]] = []
+    counts: dict[tuple[tuple[float, ...], tuple[float, float, int, int]], int] = {}
+    for g in geometries:
+        key = (_rounded_orientation(g.orientation), g.in_plane)
+        if key not in counts:
+            order.append(key)
+            counts[key] = 0
+        counts[key] += 1
+    best = max(order, key=lambda k: counts[k])
+    keep, drop = [], []
+    for g in geometries:
+        (keep if (_rounded_orientation(g.orientation), g.in_plane) == best else drop).append(g)
+    return keep, drop
+
+
+def _rounded_orientation(orientation: tuple[float, ...], decimals: int = 5) -> tuple[float, ...]:
+    """Group orientations robustly: stored cosines carry float noise well below any real difference."""
+    return tuple(round(float(x), decimals) for x in orientation)
+
+
+def validate_series(
+    geometries: Sequence[SliceGeometry],
+    *,
+    spacing_rtol: float = DEFAULT_SPACING_RTOL,
+    spacing_atol: float = DEFAULT_SPACING_ATOL,
+    angle_tol_deg: float = DEFAULT_ANGLE_TOL_DEG,
+) -> None:
+    """Raise InconsistentSeriesError unless the slices describe one consistent 3D volume."""
+    if len(geometries) < 2:
+        return  # a single slice has no inter-slice geometry to be inconsistent about
+
+    _check_in_plane(geometries)
+    _check_orientation(geometries, angle_tol_deg)
+    _check_uniform_spacing(geometries, spacing_rtol, spacing_atol)
+
+
+def _check_in_plane(geometries: Sequence[SliceGeometry]) -> None:
+    groups: dict[tuple[float, float, int, int], list[str]] = {}
+    for g in geometries:
+        groups.setdefault(g.in_plane, []).append(g.key)
+    if len(groups) == 1:
+        return
+    majority = max(groups, key=lambda k: len(groups[k]))
+    lines = [
+        f"  {in_plane} : {len(keys)} slice(s), e.g. {_sample(keys)}"
+        for in_plane, keys in sorted(groups.items(), key=lambda kv: -len(kv[1]))
+    ]
+    raise InconsistentSeriesError(
+        "DICOM series mixes different in-plane geometry (pixel spacing, rows, columns), so the "
+        "slices do not form a single volume.\n"
+        "Groups as (row_spacing, col_spacing, rows, columns):\n" + "\n".join(lines) + f"\n"
+        f"The dominant geometry is {majority}. This usually means a localizer/scout slice shares the "
+        f"Series Instance UID with the acquisition.\n" + _BYPASS_HINT
+    )
+
+
+def _check_orientation(geometries: Sequence[SliceGeometry], angle_tol_deg: float) -> None:
+    reference = geometries[0].normal
+    offenders: list[tuple[str, float]] = []
+    for g in geometries[1:]:
+        cos = float(np.clip(np.dot(g.normal, reference), -1.0, 1.0))
+        angle = float(np.degrees(np.arccos(abs(cos))))
+        if angle > angle_tol_deg:
+            offenders.append((g.key, angle))
+    if not offenders:
+        return
+    worst = sorted(offenders, key=lambda t: -t[1])
+    listed = "\n".join(f"  {key} : {angle:.4f} deg from the first slice" for key, angle in worst[:5])
+    more = f"\n  ... and {len(worst) - 5} more" if len(worst) > 5 else ""
+    raise InconsistentSeriesError(
+        f"DICOM series mixes slice orientations: {len(offenders)} of {len(geometries)} slice(s) are "
+        f"not parallel to the first (tolerance {angle_tol_deg} deg). A single 3D volume cannot "
+        f"contain slices at different orientations; this is typically a localizer/scout slice "
+        f"sharing the Series Instance UID with the acquisition.\n" + listed + more + "\n" + _BYPASS_HINT
+    )
+
+
+def _check_uniform_spacing(geometries: Sequence[SliceGeometry], rtol: float, atol: float) -> None:
+    normal = geometries[0].normal
+    projected = sorted((float(np.dot(np.asarray(g.position, float), normal)), g.key) for g in geometries)
+    positions = np.array([p for p, _ in projected])
+    keys = [k for _, k in projected]
+    gaps = np.diff(positions)
+
+    duplicates = [(keys[i], keys[i + 1]) for i, gap in enumerate(gaps) if abs(gap) <= atol]
+    if duplicates:
+        listed = "\n".join(f"  {a}\n  {b}" for a, b in duplicates[:3])
+        raise InconsistentSeriesError(
+            f"DICOM series contains {len(duplicates)} pair(s) of slices at the same position along the "
+            f"slice normal, so the slice spacing is undefined. Duplicated positions:\n" + listed + "\n" + _BYPASS_HINT
+        )
+
+    median_gap = float(np.median(gaps))
+    if median_gap <= 0:
+        raise InconsistentSeriesError(
+            f"DICOM series has a non-positive median slice gap ({median_gap}); slice positions are "
+            f"not monotonic along the slice normal.\n" + _BYPASS_HINT
+        )
+    tolerance = max(atol, rtol * abs(median_gap))
+    deviation = np.abs(gaps - median_gap)
+    bad = np.nonzero(deviation > tolerance)[0]
+    if bad.size == 0:
+        return
+    listed = "\n".join(
+        f"  gap {float(gaps[i]):.6f} mm (expected ~{median_gap:.6f}) between\n    {keys[i]}\n    {keys[i + 1]}"
+        for i in bad[:3]
+    )
+    more = f"\n  ... and {bad.size - 3} more" if bad.size > 3 else ""
+    raise InconsistentSeriesError(
+        f"DICOM series is not uniformly sampled along the slice axis: {bad.size} of {gaps.size} gap(s) "
+        f"deviate from the median gap of {median_gap:.6f} mm by more than {tolerance:.6f} mm "
+        f"(rtol={rtol}, atol={atol}). Reading it would assign every voxel a wrong slice spacing. "
+        f"This is usually a missing slice, a duplicated slice, or an extra off-axis slice.\n"
+        + listed
+        + more
+        + "\n"
+        + _BYPASS_HINT
+    )
+
+
+def resolve_series_files(
+    filenames: Sequence[str],
+    validate: bool = True,
+    keep_dominant_geometry: bool = False,
+    **tolerances: float,
+) -> list[str]:
+    """Return the filenames to read, applying the optional dominant-geometry filter and validation.
+
+    Order of operations matters: filtering happens first so that a discarded localizer does not make
+    the uniformity check fail, but validation still runs on what remains -- otherwise the filter
+    would quietly accept a stack with a genuine gap, reintroducing the silence this module removes.
+    """
+    if not validate and not keep_dominant_geometry:
+        return list(filenames)
+
+    geometries = geometries_from_files(filenames)
+    if not geometries:
+        return list(filenames)  # nothing to check (e.g. non-DICOM inputs)
+
+    kept = geometries
+    if keep_dominant_geometry:
+        kept, _dropped = select_dominant(geometries)
+    if validate:
+        validate_series(kept, **tolerances)
+
+    if not keep_dominant_geometry:
+        return list(filenames)
+    keep_keys = {g.key for g in kept}
+    return [f for f in filenames if str(f) in keep_keys]
+
+
+def resolve_series_datasets(
+    slices: Sequence[pydicom.Dataset],
+    validate: bool = True,
+    keep_dominant_geometry: bool = False,
+    **tolerances: float,
+) -> list[pydicom.Dataset]:
+    """Dataset-based counterpart of resolve_series_files, for the pydicom backend."""
+    if not validate and not keep_dominant_geometry:
+        return list(slices)
+
+    pairs = [(ds, geometry_from_dataset(ds, key=_dataset_key(ds, i))) for i, ds in enumerate(slices)]
+    geometries = [g for _, g in pairs if g is not None]
+    if not geometries:
+        return list(slices)
+
+    kept_geoms = geometries
+    if keep_dominant_geometry:
+        kept_geoms, _dropped = select_dominant(geometries)
+    if validate:
+        validate_series(kept_geoms, **tolerances)
+
+    if not keep_dominant_geometry:
+        return list(slices)
+    keep_keys = {g.key for g in kept_geoms}
+    return [ds for ds, g in pairs if g is not None and g.key in keep_keys]
+
+
+def _dataset_key(ds: pydicom.Dataset, index: int) -> str:
+    """Datasets may carry no filename, so fall back to something a human can still act on."""
+    filename = getattr(ds, "filename", None)
+    if filename:
+        return str(filename)
+    uid = getattr(ds, "SOPInstanceUID", None)
+    return f"SOPInstanceUID={uid}" if uid else f"slice #{index}"
+
+
+def _sample(keys: Sequence[str], limit: int = 2) -> str:
+    shown = ", ".join(keys[:limit])
+    return shown + (f" (+{len(keys) - limit} more)" if len(keys) > limit else "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "medio"
-version = "0.6.0"
+version = "0.7.0"
 description = "Medical images I/O Python package"
 authors = [
     { name = "RSIP Vision", email = "info@rsipvision.com" },

--- a/tests/test_dcm_series_check.py
+++ b/tests/test_dcm_series_check.py
@@ -1,0 +1,130 @@
+"""Series-geometry validation: a DICOM directory must describe ONE consistent 3D volume.
+
+The bug these tests lock down: a sagittal localizer sharing the axial SeriesInstanceUID was read
+into the volume, silently inflating the derived slice spacing (real case: 0.700mm -> 0.81662mm, a
+16.7% geometric error on a clinical scan). Grouping by SeriesInstanceUID cannot separate it, and ITK
+only emits a warning, so every read path returned a corrupted volume without failing.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pydicom
+import pydicom.uid
+import pytest
+
+import medio
+from medio.utils.dcm_series import InconsistentSeriesError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CLEAN_N = 150
+CLEAN_SPACING = 0.312999993562698
+
+
+def _copy_clean(dcm_dir: Path, dest: Path) -> Path:
+    dest.mkdir(parents=True, exist_ok=True)
+    for f in sorted(dcm_dir.glob("*.dcm")):
+        shutil.copyfile(f, dest / f.name)
+    return dest
+
+
+def _add_localizer(series_dir: Path) -> Path:
+    """Append a scout slice that mimics the real defect: different orientation and pixel spacing,
+    a position far outside the stack, but the SAME SeriesInstanceUID and matching Rows/Columns."""
+    src = sorted(series_dir.glob("*.dcm"))[0]
+    ds = pydicom.dcmread(src)
+    ds.ImageOrientationPatient = [0, 1, 0, 0, 0, -1]  # sagittal, vs the axial [-1,0,0, 0,-1,0]
+    ds.PixelSpacing = [0.4925, 0.4925]
+    pos = [float(x) for x in ds.ImagePositionPatient]
+    ds.ImagePositionPatient = [pos[0], pos[1], pos[2] + 60.0]  # well beyond the axial range
+    ds.InstanceNumber = 1  # the real localizer sorted first by InstanceNumber
+    ds.SOPInstanceUID = pydicom.uid.generate_uid()
+    out = series_dir / "LOCALIZER.dcm"
+    ds.save_as(out)
+    return out
+
+
+def _drop_middle_slice(series_dir: Path) -> None:
+    """Create a genuine gap in an otherwise consistent stack (orientation stays uniform)."""
+    files = sorted(series_dir.glob("*.dcm"), key=lambda p: float(pydicom.dcmread(p).ImagePositionPatient[2]))
+    files[len(files) // 2].unlink()
+
+
+@pytest.fixture
+def clean_series(dcm_dir: Path, tmp_path: Path) -> Path:
+    return _copy_clean(dcm_dir, tmp_path / "clean")
+
+
+@pytest.fixture
+def contaminated_series(dcm_dir: Path, tmp_path: Path) -> Path:
+    d = _copy_clean(dcm_dir, tmp_path / "contaminated")
+    _add_localizer(d)
+    return d
+
+
+@pytest.mark.parametrize("backend", ["itk", "pdcm"])
+def test_clean_series_still_reads(clean_series: Path, backend: Literal["itk", "pdcm"]) -> None:
+    """Validation must not disturb healthy data — real series are uniform to ~1e-12, far inside
+    tolerance."""
+    img, md = medio.read_img(clean_series, backend=backend)
+    assert img.shape[2] == CLEAN_N
+    assert float(np.asarray(md.spacing)[2]) == pytest.approx(CLEAN_SPACING, rel=1e-6)
+
+
+@pytest.mark.parametrize("backend", ["itk", "pdcm"])
+def test_localizer_in_series_hard_fails(contaminated_series: Path, backend: Literal["itk", "pdcm"]) -> None:
+    with pytest.raises(InconsistentSeriesError) as exc:
+        medio.read_img(contaminated_series, backend=backend)
+    msg = str(exc.value)
+    assert "LOCALIZER.dcm" in msg, "the offending file must be named so it can be investigated"
+    assert "validate_series" in msg, "the error must state how to bypass it"
+
+
+@pytest.mark.parametrize("backend", ["itk", "pdcm"])
+def test_read_meta_fails_the_same_way(contaminated_series: Path, backend: Literal["itk", "pdcm"]) -> None:
+    """read_meta previously disagreed with read_img on the pdcm backend — one raised, one did not.
+    Both paths share the validator now, so they cannot diverge."""
+    with pytest.raises(InconsistentSeriesError):
+        medio.read_meta(contaminated_series, backend=backend)
+
+
+def test_bypass_restores_the_previous_behaviour(contaminated_series: Path) -> None:
+    """The escape hatch must actually return the old (wrong) geometry rather than a repaired one --
+    callers opting out are asking for exactly what they got before."""
+    img, md = medio.read_img(contaminated_series, backend="itk", validate_series=False)
+    assert img.shape[2] == CLEAN_N + 1
+    assert float(np.asarray(md.spacing)[2]) != pytest.approx(CLEAN_SPACING, rel=1e-3)
+
+
+@pytest.mark.parametrize("backend", ["itk", "pdcm"])
+def test_opt_in_filter_drops_the_localizer(contaminated_series: Path, backend: Literal["itk", "pdcm"]) -> None:
+    img, md = medio.read_img(contaminated_series, backend=backend, keep_dominant_geometry=True)
+    assert img.shape[2] == CLEAN_N
+    assert float(np.asarray(md.spacing)[2]) == pytest.approx(CLEAN_SPACING, rel=1e-6)
+
+
+def test_missing_slice_fails_even_with_uniform_orientation(clean_series: Path) -> None:
+    """A real archive case (CT_00120) is non-uniform *within* one orientation — 96.8% gap deviation
+    from missing slices. Orientation checks alone would pass it."""
+    _drop_middle_slice(clean_series)
+    with pytest.raises(InconsistentSeriesError) as exc:
+        medio.read_img(clean_series, backend="itk")
+    assert "spacing" in str(exc.value).lower() or "uniform" in str(exc.value).lower()
+
+
+def test_filter_does_not_mask_a_genuine_gap(clean_series: Path) -> None:
+    """keep_dominant_geometry removes off-geometry slices; it must NOT paper over a real gap in the
+    slices that remain, or it becomes the silent behaviour we are removing."""
+    _drop_middle_slice(clean_series)
+    with pytest.raises(InconsistentSeriesError):
+        medio.read_img(clean_series, backend="itk", keep_dominant_geometry=True)
+
+
+def test_single_file_read_is_unaffected(nii_path: Path) -> None:
+    img, _ = medio.read_img(nii_path)
+    assert img.ndim >= 3

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ wheels = [
 
 [[package]]
 name = "medio"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "dicom-numpy" },


### PR DESCRIPTION
## The bug

Reading a DICOM directory whose slices do not form a single consistent 3D volume **silently returned a corrupted image**.

Series Instance UID does not identify a volume. Scanners emit a localizer/scout slice under the **same** `SeriesInstanceUID`, `SeriesNumber` and `SeriesDescription` as the acquisition it belongs to, differing only in orientation and pixel spacing — so neither backend's grouping (`GDCMSeriesFileNames` in itk, a UID dict in pdcm) could separate it. Because slice spacing is derived across the whole set, one distant off-axis slice stretches every voxel along the slice axis.

On a real clinical CT this turned a **0.700 mm spacing into 0.81662 mm — a 16.7% geometric error** — with no exception. Downstream, that is wrong vertebra heights, wrong physical measurements, and segmentation masks that drift progressively along the scan axis.

Neither underlying library stops it. ITK's `ImageSeriesReader` only *warns*:

```
Non uniform sampling or missing slices detected, maximum nonuniformity: 90.9503
```

Three of the four read paths were affected, and the pdcm pair **disagreed with each other**:

| path | before | after |
|---|---|---|
| `read_img` backend=itk | silently wrong | raises |
| `read_img` backend=pdcm | raised (via `dicom_numpy`) | raises |
| `read_meta` backend=itk | silently wrong | raises |
| `read_meta` backend=pdcm | silently wrong | raises |

`read_img(pdcm)` delegated to `dicom_numpy`, which validates; `read_meta(pdcm)` used an internal affine computation that did not. Same backend, same directory, one raised and one returned a corrupted affine.

## The fix

A single validator, `medio/utils/dcm_series.py`, used by **both backends and both entry points**. That structure is deliberate: the defect existed because four paths each derived geometry their own way, so a fix in one place would have left the others silent.

Three enforced invariants, each a property any single 3D volume must have:

1. all slices share one orientation (direction cosines),
2. all slices share one in-plane geometry (pixel spacing, rows, columns),
3. slice positions are uniformly spaced along the slice normal — which also catches **missing and duplicated slices**, not only localizers.

**Deliberately not enforced:** agreement between the derived spacing and `SliceThickness`. Gapped and overlapping reconstructions are legitimate, so `SliceThickness != spacing` is not an inconsistency. In the archive where this bug was found, 109 of 340 scans have them differ — enforcing it would reject roughly a third of valid data. The reason is recorded in the module docstring so it is not re-added later.

## Tolerances are measured, not chosen

Calibrated against 68 real CT series:

| | healthy series | broken stack in the same sample |
|---|---|---|
| gap deviation from median | ≤ 1e-3 relative (median 5e-14) | 9.7e-1 |
| per-slice orientation | ≤ 3.4e-5° | — |

Defaults sit ~10x above observed noise and ~100x below a real defect. Worth noting: `dicom_numpy`'s own uniformity warning fires on healthy scanner jitter of ~1e-4, which is why its strictness was not inherited — a check that cries wolf on normal data gets switched off.

## Escape hatches

A hard failure on a mission-critical path must be overridable:

```python
medio.read_img(d)                                # raises InconsistentSeriesError
medio.read_img(d, validate_series=False)         # previous behaviour, geometry still wrong
medio.read_img(d, keep_dominant_geometry=True)   # drop the localizer, read correct geometry
```

Two properties worth calling out:

- `validate_series=False` returns the **same incorrect geometry as before**, not a repaired one. An explicit opt-out should mean exactly what it says.
- `keep_dominant_geometry=True` filters **first and then still validates the remainder**, so it discards off-geometry slices without hiding a genuine gap in the ones it keeps. There is a test pinning that, because otherwise the opt-in filter would reintroduce the silence this PR removes.

`InconsistentSeriesError` subclasses `ValueError`, so callers already handling malformed input keep working. Error messages name the offending files, report observed versus expected gaps, and state how to bypass.

## Verification

Verified on the scan that exposed this (325 files = 324 axial @ 0.700 mm + 1 sagittal scout):

- all four read paths raise by default
- `validate_series=False` → 325 slices @ 0.816620 mm, unchanged
- `keep_dominant_geometry=True` → **324 slices @ 0.700000 mm on both backends**

166 tests pass (154 existing + 12 new), `ruff` clean, `ty` clean. New tests cover: clean series unaffected on both backends, localizer hard-fails on both backends, `read_img`/`read_meta` parity, bypass returns the old geometry, opt-in filter repairs it, a missing slice fails even with uniform orientation, the filter does not mask a genuine gap, and single-file reads are untouched.

## Breaking change

Reading a contaminated directory now raises where it previously returned an image. That is the intent — the alternative is continuing to return silently wrong geometry — so this is released as **0.7.0** with a `CHANGELOG.md` entry explaining the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ax6AsMowSS4hFsrquFGkpG